### PR TITLE
fix: update Store APIs per interface change

### DIFF
--- a/notation/go.mod
+++ b/notation/go.mod
@@ -3,9 +3,10 @@ module github.com/ratify-project/ratify-verifier-go/notation
 go 1.22.0
 
 require (
+	github.com/notaryproject/notation-core-go v1.2.0
 	github.com/notaryproject/notation-go v1.3.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/ratify-project/ratify-go v0.0.0-20250121002110-2815af359901
+	github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052
 	oras.land/oras-go/v2 v2.5.0
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.10 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/notaryproject/notation-core-go v1.2.0 // indirect
 	github.com/notaryproject/notation-plugin-framework-go v1.0.0 // indirect
 	github.com/notaryproject/tspclient-go v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/notation/go.mod
+++ b/notation/go.mod
@@ -6,8 +6,7 @@ require (
 	github.com/notaryproject/notation-core-go v1.2.0
 	github.com/notaryproject/notation-go v1.3.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052
-	oras.land/oras-go/v2 v2.5.0
+	github.com/ratify-project/ratify-go v0.0.0-20250210030230-fce66985bcc3
 )
 
 require (
@@ -25,4 +24,5 @@ require (
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
+	oras.land/oras-go/v2 v2.5.0 // indirect
 )

--- a/notation/go.sum
+++ b/notation/go.sum
@@ -47,8 +47,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052 h1:zc4X87yY5DCZHJNJt/IUVUVLbhZ1eRdTcaIGqiHhZDw=
-github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052/go.mod h1:15p9vbCOZTSQXgKtCpZmESshaayqoPJZPgx+J9zDO6s=
+github.com/ratify-project/ratify-go v0.0.0-20250210030230-fce66985bcc3 h1:vP3BdMFy211N7WWPt+7mZQpO3V6cJRgJhp0DjB9CWXw=
+github.com/ratify-project/ratify-go v0.0.0-20250210030230-fce66985bcc3/go.mod h1:15p9vbCOZTSQXgKtCpZmESshaayqoPJZPgx+J9zDO6s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/notation/go.sum
+++ b/notation/go.sum
@@ -47,8 +47,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/ratify-project/ratify-go v0.0.0-20250121002110-2815af359901 h1:iFKvYebw5Sdon3zj9NTFJAVP124SRNX9DE8f08NfoKk=
-github.com/ratify-project/ratify-go v0.0.0-20250121002110-2815af359901/go.mod h1:tFFtUXXVSWRbcCZd0OwpjnCeXYagPheuByTTPJ4lKDE=
+github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052 h1:zc4X87yY5DCZHJNJt/IUVUVLbhZ1eRdTcaIGqiHhZDw=
+github.com/ratify-project/ratify-go v0.0.0-20250206022400-b18f90180052/go.mod h1:15p9vbCOZTSQXgKtCpZmESshaayqoPJZPgx+J9zDO6s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/notation/verifier_test.go
+++ b/notation/verifier_test.go
@@ -160,19 +160,11 @@ func TestVerify(t *testing.T) {
 		expectedError  bool
 	}{
 		{
-			name:     "subject parse failed",
+			name:     "failed to fetch manifest",
 			verifier: &mockVerifier{},
 			opts: &ratify.VerifyOptions{
-				Subject: "invalid",
-			},
-			expectedError: true,
-		},
-		{
-			name:     "failed to fetch image manifest",
-			verifier: &mockVerifier{},
-			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
-				Store:   &mockStore{},
+				Repository: testRepo,
+				Store:      &mockStore{},
 			},
 			expectedError: true,
 		},
@@ -180,7 +172,7 @@ func TestVerify(t *testing.T) {
 			name:     "no layers in the signature manifest",
 			verifier: &mockVerifier{},
 			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
+				Repository: testRepo,
 				Store: &mockStore{
 					manifest: &ocispec.Manifest{},
 				},
@@ -191,7 +183,7 @@ func TestVerify(t *testing.T) {
 			name:     "failed to unmarshal signature manifest",
 			verifier: &mockVerifier{},
 			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
+				Repository: testRepo,
 				Store: &mockStore{
 					manifestBytes: []byte("invalid"),
 				},
@@ -202,7 +194,7 @@ func TestVerify(t *testing.T) {
 			name:     "failed to fetch blob content",
 			verifier: &mockVerifier{},
 			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
+				Repository: testRepo,
 				Store: &mockStore{
 					manifest: &ocispec.Manifest{
 						Layers: []ocispec.Descriptor{
@@ -219,7 +211,7 @@ func TestVerify(t *testing.T) {
 			name:     "failed to verify signature",
 			verifier: &mockVerifier{},
 			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
+				Repository: testRepo,
 				Store: &mockStore{
 					manifest: &ocispec.Manifest{
 						Layers: []ocispec.Descriptor{
@@ -240,7 +232,7 @@ func TestVerify(t *testing.T) {
 				verifySucceeded: true,
 			},
 			opts: &ratify.VerifyOptions{
-				Subject: testSubject,
+				Repository: testRepo,
 				Store: &mockStore{
 					manifest: &ocispec.Manifest{
 						Layers: []ocispec.Descriptor{


### PR DESCRIPTION
1. The Store interface was updated recently in PR: https://github.com/ratify-project/ratify-go/pull/33. Update the Notation verifier to use the latest Store APIs.
2. Pass artifactDesc instead of subjectDesc to fetch signature desc.
3. Prefix the registry to construct full repo path.