### PR TITLE
docs: add ratify cosign verifier design doc

### DIFF
--- a/cosign/design.md
+++ b/cosign/design.md
@@ -1,110 +1,193 @@
 # **Cosign Verifier Library Implementation Using `sigstore-go`**
 
-## Introduction
+## 1. Introduction
 
-This document outlines the design of a Cosign verifier library using the newly developed `sigstore-go` API. The goal is to implement the `sigstore/cosign` library for `ratify` verifier API, and not relying on the legacy `sigstore/sigstore` library while ensuring compatibility with the `cosign` CLI experience.
+This document outlines the design of a Cosign verifier library using the newly developed `sigstore-go` API.
+The goal is to implement the `sigstore/cosign` library for `ratify` verifier API, and not relying on the legacy `sigstore/sigstore` library while ensuring compatibility with the `cosign` CLI experience.
 
-## **2. Goals**
+## 2. Goals
 
 Implement a lightweight and efficient signature verification library.
 
-- Align closely with `cosign` verification workflows.
-- Provide a Go API that simplifies integration with policy engines like Ratify.
 - Utilize `sigstore-go` to ensure maintainability and support future updates.
+- Provide a Go API that simplifies integration with policy engines like Ratify.
+- Align closely with `cosign` verification workflows.
 
-## **3. Architecture**
+## 3. Architecture
 
-### **3.1. High-Level Flow**
+### 3.1. High-Level Flow
 
-1. **Fetch Signature & Public Key**: Retrieve the signature and associated key from a registry or local source.
-2. **Verify Signature**: Use `sigstore-go` to validate the signature.
-3. **Check Fulcio & Rekor** (if applicable): Verify against transparency logs and certificate chains.
-4. **Policy Evaluation** (Optional): Provide hooks for `cosign` policy-based verification.
+1. **Initialize Verifier, Trust Materials, Policies**: Initialize Cosign verifier with verifier options
+2. **Resolve Verify Option, Composite Verify Input**: Retrieve trust material and Cosign policy option.
+3. **Perform Verify with Trust Materials and Policies**: Use API from `sigstore-go` library to validate the signature.
 
-### **3.2. Component Breakdown**
+### 3.2. Component Breakdown
 
 | Component | Description |
 |-----------|------------|
-| `Verifier` | Core verification engine using `sigstore-go`. |
-| `RegistryFetcher` | Retrieves signatures and attestations from OCI registries.Complete the executor behavor about getting signature descriptor. |
-| `KeySource` | Loads keys from TUF, keyless (OIDC-based Fulcio), or user-provided sources. |
-| `TransparencyLogVerifier` | Interacts with Rekor for transparency log validation. |
-| `PolicyEvaluator` | (Optional) policy evaluation component. |
+| `Verifier`| Core verification engine using `sigstore-go`. |
+| `PolicyProvider`| Interface that provide identity policies. |
+| `TrustedMaterialProvider` | Interface that provides public keys, keyless identifies, and other resources needed for the trust chain. |
 
-## **4. API Design**
+## 4. Design
 
-### **4.1. Verifier Interface**
+### 4.1. Verifier Initialize
 
 ```go
-type Verifier interface {
-    // Name returns the name of the verifier.
-    Name() string
+type Verifier struct {
+    name     string
+    config   verify.VerifierConfig
+    trustMaterialProvider TrustedMaterialProvider
+    policyProvider PolicyProvider
+}
 
-    // Type returns the type name of the verifier.
-    Type() string
+type VerifierConfig struct { // nolint: revive
+    // requireObserverTimestamps requires RFC3161 timestamps and/or log
+    // integrated timestamps to verify short-lived certificates
+    requireObserverTimestamps bool
+    // observerTimestampThreshold is the minimum number of verified
+    // RFC3161 timestamps and/or log integrated timestamps in a bundle
+    observerTimestampThreshold int
+    // requireTlogEntries requires log inclusion proofs in a bundle
+    requireTlogEntries bool
+    // tlogEntriesThreshold is the minimum number of verified inclusion
+    // proofs in a bundle
+    tlogEntriesThreshold int
+    // requireSCTs requires SCTs in Fulcio certificates
+    requireSCTs bool
+    // ctlogEntriesTreshold is the minimum number of verified SCTs in
+    // a Fulcio certificate
+    ctlogEntriesThreshold int
+}
 
-    // Verifiable returns if the verifier can verify against the given artifact.
-    Verifiable(artifact ocispec.Descriptor) bool
+type PolicyProvider interface {
+    PolicyConfig(ocispec.Descriptor) PolicyConfig
+}
 
-    // Verify verifies the subject in the store against the artifact and
-    // returns the verification result.
-    Verify(ctx context.Context, opts *VerifyOptions) (*VerificationResult, error)
+type Policy{
+    ignoreIdentities      bool
+    // CertificateIdentities is defined by the sigstore-go library
+    certificateIdentities CertificateIdentities
+}
+
+type TrustMaterialProvider interface {
+    // user ocispec.Descriptor to retrive the root.TrustedMaterial
+    // root.TrustedMaterial is a interface for trust material defined by
+    // the sigstore-go library
+    TrustMaterial(ocispec.Descriptor) root.TrustedMaterial
 }
 ```
 
-### **4.2. Cosign Verify Options**
+### 4.2. Verify Options
 
-`CosignVerifyOptions` is needed for verification. Those values are preloaded when initialize the verifier and store in a trust material map, using `SubjectDescriptor` as key.
+When ratify-go executor verify API, it takes following fields as input.
 
 ```go
-type CosignVerifyOptions struct {
-    Key              string   // Public key or keyless verification
-    RekorURL         string   // Optional transparency log URL
-    CertificateChain []byte   // Optional certificate chain for Fulcio
+type VerifyOptions struct {
+    // Store is the store to access the artifacts. Required.
+    Store Store
+
+    // Repository represents the fully qualified repository name of the subject,
+    // including the registry name.
+    // Required.
+    Repository string
+
+    // SubjectDescriptor is the descriptor of the subject being verified.
+    // Required.
+    SubjectDescriptor ocispec.Descriptor
+
+    // ArtifactDescriptor is the descriptor of the artifact being verified
+    // against. Required.
+    ArtifactDescriptor ocispec.Descriptor
 }
 ```
 
-### **4.3. Cosign Verification Result**
-
-`CosignVerificationResult` is provided in `VerificationResult.Detail` as additional information that can be used to provide more context.
+With those descriptors and store to access the artifacts, the next step is to composite the cosign verify entity.
+The entity also contains public key, policies that showing the expected identity and issuer in the signing certificate. These values are preloaded when initializing the verifier.
 
 ```go
+type VerifyEntity struct {
+    // verify.SignedEntity is a interface defined by sigstore-go as the verify input
+    signedEntity        verify.SignedEntity
+    // identityPolices is a list of policy options as verify input
+    identityPolicies    []verify.PolicyOption
+}
+```
+
+**NOTE:**
+
+- Key-based verification requires providing the public key for cryptographically verification
+
+- Keyless verification finds an x509 certificate with a public key on the signature and verifies it against the Fulcio root trust (or user-supplied root trust).
+
+### 4.3. Verification Result
+
+`VerificationResult` defines the verification result that a verifier plugin
+must return.
+
+```go
+type VerificationResult struct {
+    // Err is the error that occurred when the verification failed.
+    // If the verification is successful, this field should be nil. Optional.
+    Err error
+
+    // Description describes the verification result if needed. Optional.
+    Description string
+
+    // Verifier refers to the verifier that generated the result. Required.
+    Verifier Verifier
+
+    // Detail is additional information that can be used to provide more context
+    // about the verification result. Optional.
+    Detail any
+}
+
+
+// `CosignVerificationResult` is provided in `VerificationResult.Detail` as additional information that can be used to provide more context.
+
 type CosignVerificationResult struct {
-    VerifyOptions VerifyOptions // Showing ratify verifier input
-    Signatures     []SignatureInfo
-    TransparencyLog *RekorLogInfo
+    MediaType          string                        `json:"mediaType"`
+    Signature          *SignatureVerificationResult  `json:"signature,omitempty"`
+    VerifiedTimestamps []TimestampVerificationResult `json:"verifiedTimestamps"`
+    VerifiedIdentity   *CertificateIdentity          `json:"verifiedIdentity,omitempty"`
 }
 ```
 
-### **4.3.1 SignatureInfo**
+## 5. Implementation Details
 
-```go
-type SignatureInfo struct {
-    Digest    string
-    Signer    string
-    Timestamp time.Time
-}
-```
+### 5.1. Using sigstore-go
 
-## **5. Implementation Details**
+#### 5.1.1 Legacy vs. New Implementation
 
-### **5.1. Using sigstore-go**
+| Aspect               | Legacy (`sigstore/cosign`)                                                                 | New (`sigstore-go`)                              |
+|----------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------|
+| **Structure**        | Tightly coupled to Cosign CLI                                             | Modular, reusable library for SDK/API integrations                |
+| **Verification**     | Hardcoded workflows (e.g., fixed certificate checks in `pkg/cosign`)      | Extensible via `sigstore-go` primitives (e.g., `TrustedRoot`)     |
+| **Policy Support**   | Limited to Cosign’s CLI flags                                             | Native integration with Ratify’s verify option                    |
+| **Performance**      | Optimized for CLI use cases (single-threaded verification)                | Optimized for serverless/API (caching, parallelization)           |  
 
 - Use `sigstore-go/pkg/verify` for signature verification.
-- Fetch signatures using `sigstore-go/pkg/fetch`.
 - Integrate with `sigstore-go/pkg/rekor` for transparency log checks.
 
-### **5.2. Compatibility with cosign CLI**
+### 5.2. Feature Compatibility with Cosign CLI
 
-- Ensure CLI parity by supporting verification options (`--key`, `--rekor-url`, `--certificate-chain`).
-- Handle public key and keyless verification workflows.
+#### 5.2.1 Current Features
 
-### **5.3. Integration with Ratify**
+- Verification of Cosign signatures by creating bundles for them (see [conformance tests](test/conformance/main.go) for example)
+- Verification with a Timestamp Authority (TSA)
+- Verification with Rekor (Artifact Transparency Log)
+- Structured verification results.
 
-- Implement an adapter for Ratify to use the verifier.
-- Provide a structured output compatible with Ratify policies.
+#### 5.2.2 Limitations
 
-## **6. Future Enhancements**
+- Offline signature verification is currently not supported.
+- Verification of attestations and annotations are not supported.
 
-- Enhanced error handling and logging.
-- Policy-based verification hooks.
+**NOTE:**
+The verifier allows you to use the Sigstore Public Good TUF root or your own custom trusted root containing the root/intermediate certificates of the Fulcio/TSA/Rekor instances used to sign the bundle, in order to verify common open source bundles or bundles signed by your own private Sigstore instance.
+
+## 6. Future Enhancements
+
+- Enable `Provider` multiplexer.
+- Support user-provided trusted chains.
+- Support more policy for specific timestamps e.g., signed certificate timestamp, integrated timestamp.

--- a/cosign/design.md
+++ b/cosign/design.md
@@ -1,0 +1,110 @@
+# **Cosign Verifier Library Implementation Using `sigstore-go`**
+
+## Introduction
+
+This document outlines the design of a Cosign verifier library using the newly developed `sigstore-go` API. The goal is to implement the `sigstore/cosign` library for `ratify` verifier API, and not relying on the legacy `sigstore/sigstore` library while ensuring compatibility with the `cosign` CLI experience.
+
+## **2. Goals**
+
+Implement a lightweight and efficient signature verification library.
+
+- Align closely with `cosign` verification workflows.
+- Provide a Go API that simplifies integration with policy engines like Ratify.
+- Utilize `sigstore-go` to ensure maintainability and support future updates.
+
+## **3. Architecture**
+
+### **3.1. High-Level Flow**
+
+1. **Fetch Signature & Public Key**: Retrieve the signature and associated key from a registry or local source.
+2. **Verify Signature**: Use `sigstore-go` to validate the signature.
+3. **Check Fulcio & Rekor** (if applicable): Verify against transparency logs and certificate chains.
+4. **Policy Evaluation** (Optional): Provide hooks for `cosign` policy-based verification.
+
+### **3.2. Component Breakdown**
+
+| Component | Description |
+|-----------|------------|
+| `Verifier` | Core verification engine using `sigstore-go`. |
+| `RegistryFetcher` | Retrieves signatures and attestations from OCI registries.Complete the executor behavor about getting signature descriptor. |
+| `KeySource` | Loads keys from TUF, keyless (OIDC-based Fulcio), or user-provided sources. |
+| `TransparencyLogVerifier` | Interacts with Rekor for transparency log validation. |
+| `PolicyEvaluator` | (Optional) policy evaluation component. |
+
+## **4. API Design**
+
+### **4.1. Verifier Interface**
+
+```go
+type Verifier interface {
+    // Name returns the name of the verifier.
+    Name() string
+
+    // Type returns the type name of the verifier.
+    Type() string
+
+    // Verifiable returns if the verifier can verify against the given artifact.
+    Verifiable(artifact ocispec.Descriptor) bool
+
+    // Verify verifies the subject in the store against the artifact and
+    // returns the verification result.
+    Verify(ctx context.Context, opts *VerifyOptions) (*VerificationResult, error)
+}
+```
+
+### **4.2. Cosign Verify Options**
+
+`CosignVerifyOptions` is needed for verification. Those values are preloaded when initialize the verifier and store in a trust material map, using `SubjectDescriptor` as key.
+
+```go
+type CosignVerifyOptions struct {
+    Key              string   // Public key or keyless verification
+    RekorURL         string   // Optional transparency log URL
+    CertificateChain []byte   // Optional certificate chain for Fulcio
+}
+```
+
+### **4.3. Cosign Verification Result**
+
+`CosignVerificationResult` is provided in `VerificationResult.Detail` as additional information that can be used to provide more context.
+
+```go
+type CosignVerificationResult struct {
+    VerifyOptions VerifyOptions // Showing ratify verifier input
+    Signatures     []SignatureInfo
+    TransparencyLog *RekorLogInfo
+}
+```
+
+### **4.3.1 SignatureInfo**
+
+```go
+type SignatureInfo struct {
+    Digest    string
+    Signer    string
+    Timestamp time.Time
+}
+```
+
+## **5. Implementation Details**
+
+### **5.1. Using sigstore-go**
+
+- Use `sigstore-go/pkg/verify` for signature verification.
+- Fetch signatures using `sigstore-go/pkg/fetch`.
+- Integrate with `sigstore-go/pkg/rekor` for transparency log checks.
+
+### **5.2. Compatibility with cosign CLI**
+
+- Ensure CLI parity by supporting verification options (`--key`, `--rekor-url`, `--certificate-chain`).
+- Handle public key and keyless verification workflows.
+
+### **5.3. Integration with Ratify**
+
+- Implement an adapter for Ratify to use the verifier.
+- Provide a structured output compatible with Ratify policies.
+
+## **6. Future Enhancements**
+
+- Enhanced error handling and logging.
+- Policy-based verification hooks.


### PR DESCRIPTION
This document outlines the design of a Cosign verifier library using the newly developed `sigstore-go` API. 
The goals:
- Referred to the `sigstore/cosign` library for `ratify` verifier library. Ensure compatibility with the `cosign` CLI experience.
- Use `Verifier`, `TrustMaterial` and `Policy` as verification materials.