### PR TITLE
build: bump up go version to 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       checks: write
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.24']
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.24']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/cosign/go.mod
+++ b/cosign/go.mod
@@ -3,7 +3,7 @@ module github.com/notaryproject/ratify-verifier-go/cosign
 go 1.24.0
 
 require (
-	github.com/notaryproject/ratify-go v0.0.0-20250717032624-af22764f1472
+	github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/sigstore/protobuf-specs v0.4.1

--- a/cosign/go.sum
+++ b/cosign/go.sum
@@ -216,8 +216,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/notaryproject/ratify-go v0.0.0-20250717032624-af22764f1472 h1:UPbf8JeipBnOe6Xxma5Qmtn4D91OGg7BuXGtMbuQZe0=
-github.com/notaryproject/ratify-go v0.0.0-20250717032624-af22764f1472/go.mod h1:9zfCpjdO8RBQx5nPTVW1HW5jFwil4UUx2x5j6h5m7Lg=
+github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c h1:wCyBFVMocBvZnhNkqjuPbtYBbBmrjmxsQUtl3buY60Y=
+github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c/go.mod h1:143YHpwNPodbDo7OsDWdyLeR3oqF0oOEglD5UeIQWLY=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/notation/go.mod
+++ b/notation/go.mod
@@ -1,11 +1,11 @@
 module github.com/notaryproject/ratify-verifier-go/notation
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/notaryproject/notation-core-go v1.3.0
 	github.com/notaryproject/notation-go v1.3.2
-	github.com/notaryproject/ratify-go v0.0.0-20250523033553-c475c86f66c4
+	github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c
 	github.com/opencontainers/image-spec v1.1.1
 )
 

--- a/notation/go.sum
+++ b/notation/go.sum
@@ -39,8 +39,8 @@ github.com/notaryproject/notation-go v1.3.2 h1:4223iLXOHhEV7ZPzIUJEwwMkhlgzoYFCs
 github.com/notaryproject/notation-go v1.3.2/go.mod h1:/1kuq5WuLF6Gaer5re0Z6HlkQRlKYO4EbWWT/L7J1Uw=
 github.com/notaryproject/notation-plugin-framework-go v1.0.0 h1:6Qzr7DGXoCgXEQN+1gTZWuJAZvxh3p8Lryjn5FaLzi4=
 github.com/notaryproject/notation-plugin-framework-go v1.0.0/go.mod h1:RqWSrTOtEASCrGOEffq0n8pSg2KOgKYiWqFWczRSics=
-github.com/notaryproject/ratify-go v0.0.0-20250523033553-c475c86f66c4 h1:E3gD2fNYgYzZw+8WuBKbRu3k8tXBG5aNdiJYqL5ykXs=
-github.com/notaryproject/ratify-go v0.0.0-20250523033553-c475c86f66c4/go.mod h1:9zfCpjdO8RBQx5nPTVW1HW5jFwil4UUx2x5j6h5m7Lg=
+github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c h1:wCyBFVMocBvZnhNkqjuPbtYBbBmrjmxsQUtl3buY60Y=
+github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c/go.mod h1:143YHpwNPodbDo7OsDWdyLeR3oqF0oOEglD5UeIQWLY=
 github.com/notaryproject/tspclient-go v1.0.0 h1:AwQ4x0gX8IHnyiZB1tggpn5NFqHpTEm1SDX8YNv4Dg4=
 github.com/notaryproject/tspclient-go v1.0.0/go.mod h1:LGyA/6Kwd2FlM0uk8Vc5il3j0CddbWSHBj/4kxQDbjs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
1. Bump up go version to 1.24
2. Bump up ratify-go version to latest.
3. Update ci pipelines.