### PR TITLE
fix: set result.Err when verification failed

### DIFF
--- a/cosign/go.mod
+++ b/cosign/go.mod
@@ -3,7 +3,7 @@ module github.com/notaryproject/ratify-verifier-go/cosign
 go 1.24.0
 
 require (
-	github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c
+	github.com/notaryproject/ratify-go v0.0.0-20250829072315-27c492341d9c
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/sigstore/protobuf-specs v0.4.1

--- a/cosign/go.sum
+++ b/cosign/go.sum
@@ -216,8 +216,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c h1:wCyBFVMocBvZnhNkqjuPbtYBbBmrjmxsQUtl3buY60Y=
-github.com/notaryproject/ratify-go v0.0.0-20250818061551-d370d67b849c/go.mod h1:143YHpwNPodbDo7OsDWdyLeR3oqF0oOEglD5UeIQWLY=
+github.com/notaryproject/ratify-go v0.0.0-20250829072315-27c492341d9c h1:7Xh7ikKFNLR3Cf8OlkaV3+MfkILQCOS94kSBFenjnnQ=
+github.com/notaryproject/ratify-go v0.0.0-20250829072315-27c492341d9c/go.mod h1:dxZiAQf5wyXtc9mvNEbSUp+NLcinlCJjMRijZwHr9zo=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/cosign/verifier.go
+++ b/cosign/verifier.go
@@ -280,6 +280,7 @@ func (v *Verifier) Verify(ctx context.Context, opts *ratify.VerifyOptions) (*rat
 		result.Description = "Cosign signature verification succeeded"
 	} else {
 		result.Description = "Cosign signature verification failed: no valid signatures found"
+		result.Err = errors.New("no valid signatures found, see result for details")
 	}
 	return result, nil
 }


### PR DESCRIPTION
By the defnition of Verifier API design, we should set the Err of result when verification failed, which was missed in cosign verifier.