### PR TITLE
fix: Unsafe Array Index Without Bounds Check

### DIFF
--- a/notation/verifier.go
+++ b/notation/verifier.go
@@ -115,6 +115,9 @@ func (v *Verifier) Verify(ctx context.Context, opts *ratify.VerifyOptions) (*rat
 		return result, nil
 	}
 
+	if len(outcome.EnvelopeContent.SignerInfo.CertificateChain) == 0 {
+		return nil, fmt.Errorf("notation verification returned an empty certificate chain")
+	}
 	cert := outcome.EnvelopeContent.SignerInfo.CertificateChain[0]
 	result.Detail = map[string]string{
 		"Issuer": cert.Issuer.String(),

--- a/notation/verifier_test.go
+++ b/notation/verifier_test.go
@@ -109,7 +109,19 @@ func (m *mockVerifier) Verify(_ context.Context, _ ocispec.Descriptor, _ []byte,
 	} else {
 		return nil, errors.New("verification failed")
 	}
+}
 
+// mockVerifierEmptyChain is a mock verifier that returns an empty certificate chain.
+type mockVerifierEmptyChain struct{}
+
+func (m *mockVerifierEmptyChain) Verify(_ context.Context, _ ocispec.Descriptor, _ []byte, _ notation.VerifierVerifyOptions) (*notation.VerificationOutcome, error) {
+	return &notation.VerificationOutcome{
+		EnvelopeContent: &signature.EnvelopeContent{
+			SignerInfo: signature.SignerInfo{
+				CertificateChain: []*x509.Certificate{},
+			},
+		},
+	}, nil
 }
 
 func TestNewVerifier(t *testing.T) {
@@ -225,6 +237,24 @@ func TestVerify(t *testing.T) {
 			},
 			expectedError:  false,
 			expectedResult: &ratify.VerificationResult{},
+		},
+		{
+			name:     "empty certificate chain",
+			verifier: &mockVerifierEmptyChain{},
+			opts: &ratify.VerifyOptions{
+				Repository: testRepo,
+				Store: &mockStore{
+					manifest: &ocispec.Manifest{
+						Layers: []ocispec.Descriptor{
+							{
+								Digest: testDigest2,
+							},
+						},
+					},
+					signatureBlob: []byte{},
+				},
+			},
+			expectedError: true,
 		},
 		{
 			name: "verification succeeded",


### PR DESCRIPTION
From file: `notation/verifier.go`: Line 118
```
cert := outcome.EnvelopeContent.SignerInfo.CertificateChain[0]
```
No check that CertificateChain is non-empty. If the upstream notation-go verifier returns an outcome with an empty chain, this panics with an index-out-of-bounds error, causing DoS. The panic stack trace also leaks implementation details.