### PR TITLE
feat(cosign): allow key-based verification without a timestamp

### DIFF
--- a/cosign/verifier.go
+++ b/cosign/verifier.go
@@ -96,6 +96,12 @@ type VerifierOptions struct {
 	// Only applies to keyless verification. Optional, defaults to false.
 	IgnoreCTLog bool
 
+	// IgnoreObserverTimestamps when set to true, skips observer timestamp
+	// verification (RFC3161 or log SignedEntryTimestamp), allowing key-based
+	// verification without a timestamp. Only applies to key-based verification.
+	// Optional, defaults to false.
+	IgnoreObserverTimestamps bool
+
 	// TUFOptions provides custom TUF client options for fetching trusted root.
 	// Optional.
 	TUFOptions *tuf.Options
@@ -182,7 +188,11 @@ func createVerifier(opts *VerifierOptions) (*verify.Verifier, error) {
 	}
 
 	// Configure timestamp verification
-	verifierOpts = append(verifierOpts, verify.WithObserverTimestamps(1))
+	if opts.IgnoreObserverTimestamps && opts.GetPublicKeys != nil {
+		verifierOpts = append(verifierOpts, verify.WithCurrentTime())
+	} else {
+		verifierOpts = append(verifierOpts, verify.WithObserverTimestamps(1))
+	}
 
 	// Configure certificate transparency log verification
 	if !opts.IgnoreCTLog {

--- a/cosign/verifier_test.go
+++ b/cosign/verifier_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -2314,5 +2315,125 @@ func TestVerifier_VerifySignatureLayerBundleCreationError(t *testing.T) {
 	// If there's an error, it should be in bundle creation step
 	if !strings.Contains(err.Error(), "error creating bundle") {
 		t.Logf("Got error (this might be expected): %v", err)
+	}
+}
+
+// signKeyLayer builds a cosign simple-signing layer whose message signature is
+// produced by signing the layer digest with the given ECDSA key. The returned
+// layer carries no transparency-log bundle and no timestamp, mirroring an image
+// signed offline (e.g. `cosign sign --tlog-upload=false --key ...`).
+func signKeyLayer(t *testing.T, priv *ecdsa.PrivateKey) ocispec.Descriptor {
+	t.Helper()
+
+	payload := []byte("test simple signing payload")
+	dgst := digest.FromBytes(payload)
+	digestBytes, err := hex.DecodeString(dgst.Encoded())
+	if err != nil {
+		t.Fatalf("failed to decode digest: %v", err)
+	}
+
+	sig, err := ecdsa.SignASN1(rand.Reader, priv, digestBytes)
+	if err != nil {
+		t.Fatalf("failed to sign digest: %v", err)
+	}
+
+	return ocispec.Descriptor{
+		MediaType: mediaTypeSimpleSigning,
+		Digest:    dgst,
+		Size:      int64(len(payload)),
+		Annotations: map[string]string{
+			annotationKeySignature: base64.StdEncoding.EncodeToString(sig),
+		},
+	}
+}
+
+// TestVerifier_IgnoreObserverTimestamps verifies that a key-based signature
+// without a transparency-log entry or RFC3161 timestamp is accepted only when
+// IgnoreObserverTimestamps is enabled, and rejected otherwise because no
+// observer timestamp is available.
+func TestVerifier_IgnoreObserverTimestamps(t *testing.T) {
+	ctx := context.Background()
+	repo := "test/repo"
+
+	priv, pub, err := generateTestKey()
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	sigLayer := signKeyLayer(t, priv)
+
+	manifestBytes, err := createTestManifest([]ocispec.Descriptor{sigLayer})
+	if err != nil {
+		t.Fatalf("failed to create test manifest: %v", err)
+	}
+	artifactDesc := ocispec.Descriptor{
+		ArtifactType: mediaTypeCosignArtifactSignature,
+		MediaType:    ocispec.MediaTypeImageManifest,
+		Digest:       digest.FromBytes(manifestBytes),
+		Size:         int64(len(manifestBytes)),
+	}
+
+	getPublicKeys := (&testTrustedPublicKeys{
+		configs: []*PublicKeyConfig{
+			{
+				PublicKey:          pub,
+				SignatureAlgorithm: crypto.SHA256,
+			},
+		},
+	}).GetPublicKeys
+
+	tests := []struct {
+		name                     string
+		ignoreObserverTimestamps bool
+		wantVerified             bool
+	}{
+		{
+			name:                     "ignore observer timestamps accepts key signature",
+			ignoreObserverTimestamps: true,
+			wantVerified:             true,
+		},
+		{
+			name:                     "default requires observer timestamp",
+			ignoreObserverTimestamps: false,
+			wantVerified:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockStore()
+			store.addManifest(repo, artifactDesc, manifestBytes)
+
+			verifier, err := NewVerifier(&VerifierOptions{
+				Name:                     "test-verifier",
+				GetPublicKeys:            getPublicKeys,
+				IdentityPolicies:         []verify.PolicyOption{verify.WithKey()},
+				IgnoreTLog:               true,
+				IgnoreCTLog:              true,
+				IgnoreObserverTimestamps: tt.ignoreObserverTimestamps,
+			})
+			if err != nil {
+				t.Fatalf("failed to create verifier: %v", err)
+			}
+
+			result, err := verifier.Verify(ctx, &ratify.VerifyOptions{
+				Store:              store,
+				Repository:         repo,
+				ArtifactDescriptor: artifactDesc,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error during verification: %v", err)
+			}
+
+			if tt.wantVerified {
+				if result.Err != nil {
+					t.Fatalf("expected verification to succeed, got error: %v", result.Err)
+				}
+			} else {
+				if result.Err == nil {
+					t.Fatalf("expected verification to fail without a timestamp, but it succeeded")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What this does

Adds an `AllowNoTimestamp` option to the cosign `VerifierOptions` so that a **key-based** signature can be verified when it has **no transparency-log entry and no RFC3161 timestamp** — e.g. an image signed offline or with an Azure Key Vault key using `cosign sign --tlog-upload=false --key ...`.

## Why

`createVerifier` unconditionally appended `verify.WithObserverTimestamps(1)`:

```go
// Configure timestamp verification
verifierOpts = append(verifierOpts, verify.WithObserverTimestamps(1))
```

`sigstore-go`'s `NewVerifier` then enforces that at verification time the entity must carry at least one observer timestamp (RFC3161 TSA or a Rekor `SignedEntryTimestamp`). A key signature with no tlog entry has none, so it is always rejected — even though for a public key (not a Fulcio short-lived cert) a timestamp is only used to check the signature time against the key validity window, which is skipped when there are zero timestamps. In other words, key-based no-timestamp verification is architecturally fine; only the config rejects it.

## Change

- New `VerifierOptions.AllowNoTimestamp bool` (defaults to `false`; **behavior is unchanged** unless callers opt in).
- When set, `createVerifier` uses `verify.WithCurrentTime()` — sigstore's documented escape hatch for "private deployments with long-lived code signing certificates" — instead of requiring an observer timestamp.

## Test

`TestVerifier_AllowNoTimestamp` signs a message with a local ECDSA key (no tlog, no timestamp) and asserts:
- `AllowNoTimestamp: true` → verification **succeeds**;
- default (`false`) → verification **fails** (no observer timestamp), guarding against regressions.

## Context

This is the upstream half of the fix for **notaryproject/ratify#2712**. The Ratify side (bump this dependency, expose the option on the cosign verifier config + chart, and un-skip the keyed cosign e2e cases) will follow in a separate ratify PR once this is released.
