### PR TITLE
docs: add MAINTAINERS and CODEOWNERS files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @akashsinghal @binbin-li @jimmyraywv @luisdlp @susanshi @toddysm @fseldow

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,7 @@
+Akash Singhal <akashsinghal@microsoft.com> (@akashsinghal)
+Binbin Li <libinbin@microsoft.com> (@binbin-li)
+Luis Dieguez <luisdlp@microsoft.com> (@luisdlp)
+Jimmy Ray <jimmyraywv@yahoo.com> (@jimmyraywv)
+Susan Shi <huish@microsoft.com> (@susanshi)
+Toddy Memlanden <memladen@microsoft.com> (@toddysm)
+Xinhe Li <xinhl@microsoft.com> (@fseldow)


### PR DESCRIPTION
This PR adds the `MAINTAINERS` and `CODEOWNERS` files to the ratify-verifier-go repo, which were missed during the Ratify project transition to Notary Project.

The maintainers listed match the current Ratify maintainers, consistent with the [CODEOWNERS](https://github.com/notaryproject/ratify/blob/main/CODEOWNERS) and [MAINTAINERS](https://github.com/notaryproject/ratify/blob/main/MAINTAINERS) files in the main Ratify repo.