### PR TITLE
fix(cosign): skip certificate transparency log for key-based verification

### DIFF
--- a/cosign/verifier.go
+++ b/cosign/verifier.go
@@ -194,8 +194,11 @@ func createVerifier(opts *VerifierOptions) (*verify.Verifier, error) {
 		verifierOpts = append(verifierOpts, verify.WithObserverTimestamps(1))
 	}
 
-	// Configure certificate transparency log verification
-	if !opts.IgnoreCTLog {
+	// Configure certificate transparency log verification. Key-based
+	// verification carries no Fulcio certificate and therefore no signed
+	// certificate timestamps, so the certificate transparency log never applies
+	// there and IgnoreCTLog is a no-op for it.
+	if !opts.IgnoreCTLog && opts.GetPublicKeys == nil {
 		verifierOpts = append(verifierOpts, verify.WithSignedCertificateTimestamps(1))
 	}
 

--- a/cosign/verifier_test.go
+++ b/cosign/verifier_test.go
@@ -2437,3 +2437,80 @@ func TestVerifier_IgnoreObserverTimestamps(t *testing.T) {
 		})
 	}
 }
+
+// TestVerifier_IgnoreCTLog verifies that the certificate transparency log never
+// applies to key-based verification: a public-key signature is accepted
+// regardless of IgnoreCTLog, because public keys carry no signed certificate
+// timestamps. Before the GetPublicKeys gate, IgnoreCTLog=false forced an SCT
+// requirement that a public-key bundle can never satisfy.
+func TestVerifier_IgnoreCTLog(t *testing.T) {
+	ctx := context.Background()
+	repo := "test/repo"
+
+	priv, pub, err := generateTestKey()
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	sigLayer := signKeyLayer(t, priv)
+
+	manifestBytes, err := createTestManifest([]ocispec.Descriptor{sigLayer})
+	if err != nil {
+		t.Fatalf("failed to create test manifest: %v", err)
+	}
+	artifactDesc := ocispec.Descriptor{
+		ArtifactType: mediaTypeCosignArtifactSignature,
+		MediaType:    ocispec.MediaTypeImageManifest,
+		Digest:       digest.FromBytes(manifestBytes),
+		Size:         int64(len(manifestBytes)),
+	}
+
+	getPublicKeys := (&testTrustedPublicKeys{
+		configs: []*PublicKeyConfig{
+			{
+				PublicKey:          pub,
+				SignatureAlgorithm: crypto.SHA256,
+			},
+		},
+	}).GetPublicKeys
+
+	// The certificate transparency log does not apply to public keys, so
+	// key-based verification succeeds regardless of the IgnoreCTLog value.
+	tests := []struct {
+		name        string
+		ignoreCTLog bool
+	}{
+		{name: "ignoreCTLog false accepts key signature", ignoreCTLog: false},
+		{name: "ignoreCTLog true accepts key signature", ignoreCTLog: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockStore()
+			store.addManifest(repo, artifactDesc, manifestBytes)
+
+			verifier, err := NewVerifier(&VerifierOptions{
+				Name:                     "test-verifier",
+				GetPublicKeys:            getPublicKeys,
+				IdentityPolicies:         []verify.PolicyOption{verify.WithKey()},
+				IgnoreTLog:               true,
+				IgnoreCTLog:              tt.ignoreCTLog,
+				IgnoreObserverTimestamps: true,
+			})
+			if err != nil {
+				t.Fatalf("failed to create verifier: %v", err)
+			}
+
+			result, err := verifier.Verify(ctx, &ratify.VerifyOptions{
+				Store:              store,
+				Repository:         repo,
+				ArtifactDescriptor: artifactDesc,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error during verification: %v", err)
+			}
+			if result.Err != nil {
+				t.Fatalf("expected verification to succeed with ignoreCTLog=%v, got error: %v", tt.ignoreCTLog, result.Err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Key-based (public-key) cosign verification carries no Fulcio certificate and therefore no signed certificate timestamps (SCTs), so the certificate transparency log never applies to it. Today `createVerifier` requires an SCT whenever `IgnoreCTLog` is false, without distinguishing key-based from keyless:

```go
if !opts.IgnoreCTLog {
    verifierOpts = append(verifierOpts, verify.WithSignedCertificateTimestamps(1))
}
```

For a public-key bundle this makes sigstore-go reject with `"SCTs required but bundle is signed with a public key, which cannot contain SCTs"`.

## Change

Gate the SCT requirement on non-key entities, mirroring the observer-timestamp handling just above it:

```go
if !opts.IgnoreCTLog && opts.GetPublicKeys == nil {
    verifierOpts = append(verifierOpts, verify.WithSignedCertificateTimestamps(1))
}
```

Now the certificate transparency log is a no-op for key-based verification: `IgnoreCTLog` is honored for keyless (unchanged) and inert for key-based (where it can never apply). This lets consumers keep `IgnoreCTLog` a plain keyless-only option without special-casing the key path.

## Test

`TestVerifier_IgnoreCTLog` — a fully offline, key-signed image verifies with both `IgnoreCTLog: false` and `true`. Reverting the gate makes the `false` case fail (`no valid signatures found`), confirming the test guards the fix. Full `go test ./...` in `cosign/` passes.

## Context

Unblocks notaryproject/ratify#2813 and lets ratify drop the `IgnoreCTLog = true` hardcode on its key path (notaryproject/ratify#2838).
